### PR TITLE
Container state control

### DIFF
--- a/app/js/actions/init.js
+++ b/app/js/actions/init.js
@@ -14,6 +14,7 @@ var _actions = keymirror({
     listInstances: null,
 
     // Docker
+    inspectContainer: null,
     listContainers: null,
     startContainer: null,
     stopContainer: null,

--- a/app/js/docker/dockerService.js
+++ b/app/js/docker/dockerService.js
@@ -71,6 +71,7 @@ function dockerService($http, actions, flux, configService) {
 
     return {
         'containers': {
+            'inspect': d('GET', '/containers/{id}/json', actions.inspectContainer),
             'list':    d('GET', '/containers/json', actions.listContainers),
             'start':   d('POST', '/containers/{id}/start', actions.startContainer),
             'stop':    d('POST', '/containers/{id}/stop', actions.stopContainer),

--- a/app/js/docker/dockerService.js
+++ b/app/js/docker/dockerService.js
@@ -31,17 +31,17 @@ function dockerService($http, actions, flux, configService) {
      * @param {string, required} url: Docker API URL
      * @param {string, required} action: application action to dispatch with response data
      * @param {string, required} host: lighthouse alias for targeted Docker instance
-     * @param {string} id: Docker generated id for image or container
+     * @param {string} cid: Docker generated id for image or container
      * @param {object} data: if method is GET, set data as query parameters,
      *                       if POST, set in request body under 'Payload' key
      *
      * Note: The exposed interface is shortened to just (host, id, data)
      * via a partial function application.
      */
-    function docker(method, url, action, host, id, data) {
+    function docker(method, url, action, host, cid, data) {
         var config = {
             method: method,
-            url: prepareUrl(url, host, id),
+            url: prepareUrl(url, host, cid),
             responseType: 'json',
             params: method === 'GET' ? data : null,
             data: method === 'POST' ? {Payload: data} : null
@@ -50,7 +50,8 @@ function dockerService($http, actions, flux, configService) {
         $http(config).then(
             // success
             function (response) {
-                flux.dispatch(action, response.data);
+                flux.dispatch(action,
+                    {'id': cid, 'host': host, 'response': response.data});
             },
             // error
             function (response) {
@@ -65,7 +66,7 @@ function dockerService($http, actions, flux, configService) {
      * @param *: (see dockerService.docker)
      * Returns the partially applied docker function.
      */
-    function d(method, url, action, host, id, data) {
+    function d(method, url, action, host, cid, data) {
         return _.partial(docker, method, url, action);
     }
 

--- a/app/js/instances/containerController.js
+++ b/app/js/instances/containerController.js
@@ -1,0 +1,18 @@
+/*
+ * instances/containerController.js
+ * Manages interactions for a single Docker container
+ */
+
+function containerController($scope, $routeParams, dockerService, instanceModel) {
+    'use strict';
+
+    $scope.host = $routeParams.host;
+    $scope.id = $routeParams.id;
+
+    $scope.$listenTo(instanceModel, function () {
+        $scope.info = instanceModel.getContainer($scope.id);
+    });
+}
+
+containerController.$inject = ['$scope', '$routeParams', 'dockerService', 'instanceModel'];
+module.exports = containerController;

--- a/app/js/instances/containerController.js
+++ b/app/js/instances/containerController.js
@@ -11,7 +11,33 @@ function containerController($scope, $routeParams, dockerService, instanceModel)
 
     $scope.$listenTo(instanceModel, function () {
         $scope.info = instanceModel.getContainer($scope.id);
+
+        if ($scope.info) {
+            var dState = $scope.info.State;
+            $scope.state = {
+                running: dState.Running && !dState.Paused,
+                paused: dState.Paused,
+                restarting: dState.Restarting,
+                stopped: !(dState.Running || dState.Paused || dState.Restarting)
+            };
+        }
     });
+
+    $scope.start = function (id) {
+        dockerService.containers.start($scope.host, id, null);
+    };
+
+    $scope.stop = function (id) {
+        dockerService.containers.stop($scope.host, id, null);
+    };
+
+    $scope.pause = function (id) {
+        dockerService.containers.pause($scope.host, id, null);
+    };
+
+    $scope.unpause = function (id) {
+        dockerService.containers.unpause($scope.host, id, null);
+    };
 }
 
 containerController.$inject = ['$scope', '$routeParams', 'dockerService', 'instanceModel'];

--- a/app/js/instances/init.js
+++ b/app/js/instances/init.js
@@ -1,7 +1,8 @@
 // instances/init.js
 // Handles discovery and display of Docker host instances
 
-var instanceController = require('./instanceController'),
+var containerController = require('./containerController'),
+    instanceController = require('./instanceController'),
     instanceDetailController = require('./instanceDetailController'),
     instanceModel = require('./instanceModel'),
     instanceService = require('./instanceService');
@@ -10,8 +11,10 @@ var instanceController = require('./instanceController'),
 var instances = angular.module('lighthouse.instances', []);
 
 // register module components
+instances.controller('containerController', containerController);
 instances.controller('instanceController', instanceController);
 instances.controller('instanceDetailController', instanceDetailController);
+
 instances.factory('instanceService', instanceService);
 instances.store('instanceModel', instanceModel);
 

--- a/app/js/instances/instanceDetailController.js
+++ b/app/js/instances/instanceDetailController.js
@@ -27,11 +27,18 @@ function instanceDetailController($scope, $routeParams, dockerService, instanceM
 
     // View handlers
     $scope.getImages = function() {
-        dockerService.images.list($scope.instance.name, null, {all: $scope.allImages});
+        dockerService.images.list(
+            $scope.instance.name, null, {all: $scope.allImages});
     };
 
     $scope.getContainers = function () {
-        dockerService.containers.list($scope.instance.name, null, {all: $scope.allContainers});
+        dockerService.containers.list(
+            $scope.instance.name, null, {all: $scope.allContainers});
+    };
+
+    $scope.inspect = function (id) {
+        dockerService.containers.inspect(
+            $scope.instance.name, id);
     };
 }
 

--- a/app/js/instances/instanceModel.js
+++ b/app/js/instances/instanceModel.js
@@ -3,19 +3,39 @@
  * Stores state related to a particular Docker instance.
  */
 
+var _ = require('lodash');
+
+/*
+ * @return shortened container Id hash
+ */
+function id(c) {
+    return c.Id.slice(0, 10);
+}
+
 function instanceModel() {
+    'use strict';
+
     return {
         // State
         hostName: '',
-        containers: [],
+        containers: {},
         images: [],
         instances: [],
 
         // Event handlers
         handlers: {
+            'inspectContainer': 'inspectContainer',
             'listInstances': 'listInstances',
             'listContainers': 'listContainers',
             'listImages': 'listImages'
+        },
+
+        inspectContainer: function (c) {
+            var update = this.containers[id(c)];
+            if (update) {
+                update.detail = c;
+                this.emitChange();
+            }
         },
 
         listInstances: function (instances) {
@@ -24,7 +44,15 @@ function instanceModel() {
         },
 
         listContainers: function (containers) {
-            this.containers = containers;
+            // Store containers, indexed by their shortened Docker id
+            this.containers = _.indexBy(_.map(containers, function (c) {
+                // Build model
+                return { summary: c, detail: null };
+            }), function (c) {
+                // Generate key
+                return id(c.summary);
+            });
+
             this.emitChange();
         },
 
@@ -36,7 +64,14 @@ function instanceModel() {
         // State access
         exports: {
             getContainers: function () {
-                return this.containers;
+                return _.map(this.containers, function (c) {
+                    return c.summary;
+                });
+            },
+
+            getContainer: function (id) {
+                var c = this.containers[id.slice(0, 10)];
+                return c ? c.detail : undefined;
             },
 
             getInstances: function () {

--- a/app/js/instances/instanceService.js
+++ b/app/js/instances/instanceService.js
@@ -10,7 +10,7 @@ function instanceService($http, actions, flux, configService) {
         $http.get(request).then(
             // success
             function (response) {
-                flux.dispatch(actions.listInstances, response.data);
+                flux.dispatch(actions.listInstances, {'response': response.data});
             },
             // error
             function (response) {

--- a/app/js/instances/templates/container.html
+++ b/app/js/instances/templates/container.html
@@ -1,0 +1,4 @@
+<div class="container">
+    <h3>Container {{id}} on {{host}}</h3>
+    <pre>{{info | stringify}}</pre>
+</div>

--- a/app/js/instances/templates/container.html
+++ b/app/js/instances/templates/container.html
@@ -47,8 +47,7 @@
           Docker Response
         </div>
         <div class="panel-body" style="padding: 0;">
-          <pre style="border: 0; margin: 0; font-size: 12px;">
-            {{info | stringify}}</pre>
+          <pre style="border: 0; margin: 0; font-size: 12px;">{{info | stringify}}</pre>
         </div>
       </div>
     </div>

--- a/app/js/instances/templates/container.html
+++ b/app/js/instances/templates/container.html
@@ -1,4 +1,18 @@
 <div class="container">
-    <h3>Container {{id}} on {{host}}</h3>
-    <pre>{{info | stringify}}</pre>
+  <ol class="breadcrumb">
+    <li><a href="/instances">Instances</a></li>
+    <li><a href="/instances/{{host}}">{{host}}</a></li>
+    <li>containers</li>
+    <li>{{id}}</li>
+  </ol>
+
+  <h3>Container {{id}} on {{host}}</h3>
+  <div class="panel panel-primary">
+    <div class="panel-heading">
+      Response
+    </div>
+    <div class="panel-body" style="padding: 0;">
+      <pre>{{info | stringify}}</pre>
+    </div>
+  </div>
 </div>

--- a/app/js/instances/templates/container.html
+++ b/app/js/instances/templates/container.html
@@ -1,18 +1,56 @@
 <div class="container">
-  <ol class="breadcrumb">
-    <li><a href="/instances">Instances</a></li>
-    <li><a href="/instances/{{host}}">{{host}}</a></li>
-    <li>containers</li>
-    <li>{{id}}</li>
-  </ol>
-
-  <h3>Container {{id}} on {{host}}</h3>
-  <div class="panel panel-primary">
-    <div class="panel-heading">
-      Response
+  <div class="row">
+    <div class="col-md-12">
+      <ol class="breadcrumb">
+        <li><a href="/instances">Instances</a></li>
+        <li><a href="/instances/{{host}}">{{host}}</a></li>
+        <li>containers</li>
+        <li>{{id}}</li>
+      </ol>
     </div>
-    <div class="panel-body" style="padding: 0;">
-      <pre>{{info | stringify}}</pre>
+  </div>
+
+  <div class="row">
+    <div class="col-md-12 clearfix">
+      <div class="btn-group btn-group-sm pull-left" role="group"
+           style="padding-right: 10px;">
+        <button ng-if="state.stopped" type="button" class="btn btn-default"
+                ng-click="start(id)">
+          <span class="glyphicon glyphicon-play"></span> Start</button>
+
+        <button ng-if="state.paused" type="button" class="btn btn-default"
+                ng-click="unpause(id)">
+          <span class="glyphicon glyphicon-play"></span> Unpause</button>
+
+        <button ng-if="state.running" type="button" class="btn btn-default"
+                ng-click="pause(id)">
+          <span class="glyphicon glyphicon-pause"></span> Pause</button>
+
+        <button ng-if="state.running || state.paused" type="button" class="btn btn-default"
+                ng-click="stop(id)">
+          <span class="glyphicon glyphicon-stop"></span> Stop</button>
+      </div>
+
+      <h4>Container <code>{{id}}</code> on {{host}} is
+        <code ng-if="state.running"> Running</code>
+        <code ng-if="state.stopped"> Stopped</code>
+        <code ng-if="state.paused"> Paused</code>
+        <code ng-if="state.restarting"> Restarting</code>
+      </h4>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-12">
+      <div class="panel panel-primary">
+        <div class="panel-heading">
+          Docker Response
+        </div>
+        <div class="panel-body" style="padding: 0;">
+          <pre style="border: 0; margin: 0; font-size: 12px;">
+            {{info | stringify}}</pre>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/app/js/instances/templates/instance.html
+++ b/app/js/instances/templates/instance.html
@@ -45,8 +45,8 @@
         </thead>
         <tbody>
           <tr ng-repeat="image in images track by image.Id">
-            <td>{{ image.Id | shorten:6 }}</td>
-            <td>{{ image.ParentId | shorten:6 }}</td>
+            <td>{{ image.Id | shorten:10 }}</td>
+            <td>{{ image.ParentId | shorten:10 }}</td>
             <td>{{ image.RepoTags }}</td>
             <td>{{ image.Size }}</td>
             <td>{{ image.VirtualSize }}</td>
@@ -80,7 +80,12 @@
         </thead>
         <tbody>
           <tr ng-repeat="container in containers track by container.Id">
-            <td>{{ container.Id | shorten:6 }}</td>
+            <td>
+              <a href="/instances/{{instance.name}}/container/{{container.Id | shorten:10}}"
+                 ng-click="inspect(container.Id)">
+                {{container.Id | shorten:10}}
+              </a>
+            </td>
             <td>{{ container.Status }}</td>
             <td>{{ container.Image }}</td>
             <td>{{ container.Command }}</td>

--- a/app/js/instances/templates/instance.html
+++ b/app/js/instances/templates/instance.html
@@ -21,41 +21,6 @@
       </dl>
     </div>
   </div>
-  <!-- Images -->
-  <div class="row">
-    <div class="col-md-12">
-      <h3>Images</h3>
-      <div class="checkbox">
-        <label><input type="checkbox" ng-model="allImages" ng-click="getImages()"> Show all</label>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-12">
-      <table class="table table-hover table-condensed">
-        <thead>
-          <tr>
-            <th>ID</th>
-            <th>Parent ID</th>
-            <th>Repo tags</th>
-            <th>Size</th>
-            <th>Virtual Size</th>
-            <th>Created</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr ng-repeat="image in images track by image.Id">
-            <td>{{ image.Id | shorten:10 }}</td>
-            <td>{{ image.ParentId | shorten:10 }}</td>
-            <td>{{ image.RepoTags }}</td>
-            <td>{{ image.Size }}</td>
-            <td>{{ image.VirtualSize }}</td>
-            <td>{{ image.Created | fromEpoch:true }}</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  </div>
   <!-- Containers -->
   <div class="row">
     <div class="col-md-12">
@@ -91,6 +56,41 @@
             <td>{{ container.Command }}</td>
             <td>{{ container.Created | fromEpoch:true }}</td>
             <td>{{ container.Ports }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <!-- Images -->
+  <div class="row">
+    <div class="col-md-12">
+      <h3>Images</h3>
+      <div class="checkbox">
+        <label><input type="checkbox" ng-model="allImages" ng-click="getImages()"> Show all</label>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <table class="table table-hover table-condensed">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Parent ID</th>
+            <th>Repo tags</th>
+            <th>Size</th>
+            <th>Virtual Size</th>
+            <th>Created</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr ng-repeat="image in images track by image.Id">
+            <td>{{ image.Id | shorten:10 }}</td>
+            <td>{{ image.ParentId | shorten:10 }}</td>
+            <td>{{ image.RepoTags }}</td>
+            <td>{{ image.Size }}</td>
+            <td>{{ image.VirtualSize }}</td>
+            <td>{{ image.Created | fromEpoch:true }}</td>
           </tr>
         </tbody>
       </table>

--- a/app/js/instances/tests/instanceModel.spec.js
+++ b/app/js/instances/tests/instanceModel.spec.js
@@ -17,22 +17,22 @@ describe('instanceModel', function () {
     });
 
     it('should store container summaries', function () {
-        flux.dispatch(actions.listContainers, containers);
+        flux.dispatch(actions.listContainers, {response: containers});
         expect(instanceModel.getContainers()).toEqual(containers);
     });
 
     it('should store container details', function () {
-        flux.dispatch(actions.listContainers, containers);
+        flux.dispatch(actions.listContainers, {response: containers});
 
         var detail = {Id: 'one', here: 'is', some: 'data'};
-        flux.dispatch(actions.inspectContainer, detail);
+        flux.dispatch(actions.inspectContainer, {response: detail});
 
         expect(instanceModel.getContainer('one')).toEqual(detail);
     });
 
     it('should not allow storage of unknown containers', function () {
-        flux.dispatch(actions.listContainers, containers);
-        flux.dispatch(actions.inspectContainer, {Id: 'three', some: 'data'});
+        flux.dispatch(actions.listContainers, {response: containers});
+        flux.dispatch(actions.inspectContainer, {response: {Id: 'three', some: 'data'}});
         expect(instanceModel.getContainer('three')).toBe(undefined);
     });
 });

--- a/app/js/instances/tests/instanceModel.spec.js
+++ b/app/js/instances/tests/instanceModel.spec.js
@@ -1,0 +1,38 @@
+describe('instanceModel', function () {
+
+    var _ = require('lodash');
+    var actions,
+        flux,
+        instanceModel;
+
+    var containers = [{Id: 'one', a: 10, b: 100}, {Id: 'two', a: 20, b: 200}];
+
+    beforeEach(function () {
+        angular.mock.module('lighthouse.app');
+        angular.mock.inject(function (_actions_, _flux_, _instanceModel_) {
+            actions = _actions_;
+            flux = _flux_;
+            instanceModel = _instanceModel_;
+        });
+    });
+
+    it('should store container summaries', function () {
+        flux.dispatch(actions.listContainers, containers);
+        expect(instanceModel.getContainers()).toEqual(containers);
+    });
+
+    it('should store container details', function () {
+        flux.dispatch(actions.listContainers, containers);
+
+        var detail = {Id: 'one', here: 'is', some: 'data'};
+        flux.dispatch(actions.inspectContainer, detail);
+
+        expect(instanceModel.getContainer('one')).toEqual(detail);
+    });
+
+    it('should not allow storage of unknown containers', function () {
+        flux.dispatch(actions.listContainers, containers);
+        flux.dispatch(actions.inspectContainer, {Id: 'three', some: 'data'});
+        expect(instanceModel.getContainer('three')).toBe(undefined);
+    });
+});

--- a/app/js/routes/routeConfig.js
+++ b/app/js/routes/routeConfig.js
@@ -18,6 +18,10 @@ function routeConfig($routeProvider) {
             template: require('../instances/templates/instance.html'),
             controller: 'instanceDetailController'
         })
+        .when('/instances/:host/container/:id', {
+            template: require('../instances/templates/container.html'),
+            controller: 'containerController'
+        })
         .otherwise({ redirectTo: '/' });
 }
 

--- a/app/js/transform/init.js
+++ b/app/js/transform/init.js
@@ -33,4 +33,15 @@ transform.filter('fromEpoch', function() {
 
 });
 
+/*
+ * stringify (filter)
+ * @param {object} obj - to stringify
+ */
+transform.filter('stringify', function() {
+    return function(obj) {
+        // four spaces
+        return JSON.stringify(obj, null, '    ');
+    };
+});
+
 module.exports = transform;


### PR DESCRIPTION
These changes incorporate some basic container state control into the system. From an instance page, one can now click on a container ID and get redirected to a container page. The container page (shown below) allows for some basic control (starting, stopping, pausing, un-pausing) and relays the detailed container response model.

The `instanceModel` now stores the basic summary of a container (returned from `/containers/json`) as well as the detailed model (from `/containers/{id}/json`), which is fetched upon request.

![screen shot 2015-02-05 at 8 45 43 pm](https://cloud.githubusercontent.com/assets/965744/6073726/fb386466-ad77-11e4-82cf-36957b0c1ef6.png)
