### PR TITLE
File create tool

### DIFF
--- a/tools/new.py
+++ b/tools/new.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python
+
+import sys
+
+# license header file
+LICENSE = 'NOTICE.comment'
+
+# file to create
+target = sys.argv[1]
+
+# copy to new file
+with open(target, 'w') as new:
+    with open(LICENSE, 'r') as license:
+        new.write(license.read())
+        license.close()
+
+    new.close()


### PR DESCRIPTION
Little helper to create new files with the commented license notice at the top. Simply run `./tools/new.py <new file path>` from the **root** client directory and hack away! For example, if I wanted to add a new file to the auth module, I would run

```sh
./tools/new.py app/js/auth/authNew.js
```

Note that the module directory must exist first.